### PR TITLE
feat: 使header侧边栏根据具体路由采用不同的显示方式

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,27 +1,27 @@
-import { FC, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { Outlet, useLocation } from 'react-router-dom'
 import Header from './components/common/header'
-import { HEADER_WHITE_LIST } from './utils/constants'
+import { SIDEBAR_WHITE_LIST } from './utils/constants'
 
 const App: FC = () => {
-  const [showSideBar, setShowSideBar] = useState(false)
-
   const location = useLocation()
+  const [showSideBar, setShowSideBar] = useState(false)
+  const [width, setWidth] = useState('100%')
+
+  useEffect(() => {
+    setWidth(
+      showSideBar &&
+        location.pathname !== '/login' &&
+        SIDEBAR_WHITE_LIST.includes(location.pathname)
+        ? 'calc(100% - 240px)'
+        : '100%',
+    )
+  }, [showSideBar, location.pathname])
 
   return (
     <div className=''>
-      {!HEADER_WHITE_LIST.test(location.pathname) && (
-        <Header changeSideBarStatus={setShowSideBar} />
-      )}
-
-      <div
-        style={{
-          width:
-            showSideBar && !HEADER_WHITE_LIST.test(location.pathname)
-              ? 'calc(100% - 240px)'
-              : '100%',
-        }}
-        className='absolute right-0 flex transition-all duration-300'>
+      {location.pathname !== '/login' && <Header changeSideBarStatus={setShowSideBar} />}
+      <div style={{ width }} className='absolute right-0 flex transition-all duration-300'>
         <Outlet />
       </div>
     </div>

--- a/src/components/common/header/index.tsx
+++ b/src/components/common/header/index.tsx
@@ -1,27 +1,35 @@
 import { FC, useEffect, useState } from 'react'
+import { SIDEBAR_WHITE_LIST } from '@/utils/constants'
 import logo from '@/assets/svgs/logo.svg'
 import { Icon } from '@iconify/react'
 import { Input, Button } from 'antd'
 import { useSelector } from 'react-redux'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useLocation } from 'react-router-dom'
 import type { AppState } from '@/store/types'
 import UserDropdown from './user-dropdown'
 import SearchDropdown from './search-dropdown'
 import Sidebar from './sidebar'
+
+const { Search } = Input
 
 type HomeProps = {
   changeSideBarStatus: (status: boolean) => void
 }
 
 const Header: FC<HomeProps> = ({ changeSideBarStatus }) => {
+  const location = useLocation()
   const navigate = useNavigate()
-  const [showSidebar, setShowSidebar] = useState(true)
+  const [showSidebar, setShowSidebar] = useState(false)
   const [showUserDropdown, setShowUserDropdown] = useState(false)
   const [showSearchDropdown, setShowSearchDropdown] = useState(false)
 
   useEffect(() => {
     changeSideBarStatus(showSidebar)
   }, [showSidebar])
+
+  useEffect(() => {
+    setShowSidebar(SIDEBAR_WHITE_LIST.includes(location.pathname))
+  }, [location.pathname])
 
   const userInfo = useSelector((state: AppState) => state.user.userInfo)
 
@@ -34,41 +42,50 @@ const Header: FC<HomeProps> = ({ changeSideBarStatus }) => {
   }
 
   return (
-    <div className='select-none relative flex justify-between items-center w-full h-16 bg-white px-10'>
-      <Icon
-        className='fixed cursor-pointer z-9'
-        width={24}
-        color='#858585'
-        icon='ant-design:menu-outlined'
-        onClick={() => setShowSidebar(true)}
-      />
-      <img className='ml-34px h-10 cursor-pointer' src={logo} alt='picals-logo' />
-
+    <>
       <div
         style={{
-          zIndex: showSearchDropdown ? 1000 : 0,
+          zIndex: showSearchDropdown ? 2000 : 0,
         }}
-        className='absolute w-30% top-1/2 left-1/2 -translate-x-50% -translate-y-50%'>
-        <Input.Search
-          size='large'
-          placeholder='请输入你想搜索的内容呀~'
-          allowClear
-          onFocus={() => setShowSearchDropdown(true)}
-          onSearch={(value) => handleSearch(value)}
+        className='select-none relative flex justify-between items-center w-full h-16 bg-white px-10'>
+        <Icon
+          className='fixed cursor-pointer z-9'
+          width={24}
+          color='#858585'
+          icon='ant-design:menu-outlined'
+          onClick={() => setShowSidebar(true)}
         />
-      </div>
+        <img
+          onClick={() => {
+            navigate('/home')
+          }}
+          className='ml-34px h-10 cursor-pointer'
+          src={logo}
+          alt='picals-logo'
+        />
 
-      <div className='flex items-center gap-5'>
-        <Link to='/upload'>
-          <Button shape='round' type='default' size='large'>
-            <span className='color-#6d757a'>投稿作品</span>
-          </Button>
-        </Link>
-        <Icon width={24} color='#858585' icon='ant-design:bell-filled' />
-        <div
-          className='w-10 h-10 border-rd-20 flex items-center justify-center overflow-hidden cursor-pointer'
-          onClick={() => setShowUserDropdown(!showUserDropdown)}>
-          <img className='w-10' src={userInfo.avatar} alt='avatar' />
+        <div className='absolute w-30% top-1/2 left-1/2 -translate-x-50% -translate-y-50%'>
+          <Search
+            size='large'
+            placeholder='请输入你想搜索的内容呀~'
+            allowClear
+            onFocus={() => setShowSearchDropdown(true)}
+            onSearch={(value) => handleSearch(value)}
+          />
+        </div>
+
+        <div className='flex items-center gap-5'>
+          <Link to='/upload'>
+            <Button shape='round' type='default' size='large'>
+              <span className='color-#6d757a'>投稿作品</span>
+            </Button>
+          </Link>
+          <Icon width={24} color='#858585' icon='ant-design:bell-filled' />
+          <div
+            className='w-10 h-10 border-rd-20 flex items-center justify-center overflow-hidden cursor-pointer'
+            onClick={() => setShowUserDropdown(!showUserDropdown)}>
+            <img className='w-10' src={userInfo.avatar} alt='avatar' />
+          </div>
         </div>
       </div>
 
@@ -85,7 +102,7 @@ const Header: FC<HomeProps> = ({ changeSideBarStatus }) => {
         visible={showUserDropdown}
         setVisible={setShowUserDropdown}
       />
-    </div>
+    </>
   )
 }
 

--- a/src/components/common/header/search-dropdown.tsx
+++ b/src/components/common/header/search-dropdown.tsx
@@ -20,14 +20,14 @@ const SearchDropdown: FC<{
 
       <CSSTransition in={visible} timeout={300} classNames='opacity-gradient' unmountOnExit>
         <div
-          className='fixed top-0 left-0 w-full h-full bg-black bg-opacity-16 z-999'
+          className='fixed top-0 left-0 w-full h-full bg-black bg-opacity-32 z-1999'
           onClick={() => setVisible(false)}
         />
       </CSSTransition>
 
       <CSSTransition in={visible} timeout={300} classNames='opacity-gradient' unmountOnExit>
         <div
-          className={`not-show-scrollbar absolute bg-#fff w-545px rd-6px overflow-hidden z-1000 ${className} select-none`}>
+          className={`not-show-scrollbar absolute bg-#fff w-545px rd-6px overflow-hidden z-2000 ${className} select-none`}>
           <div className='m-b-5'>
             <div className='w-full p-10px flex justify-between items-center'>
               <span className='font-bold font-size-14px color-#6d757a'>历史记录</span>

--- a/src/components/common/header/sidebar.tsx
+++ b/src/components/common/header/sidebar.tsx
@@ -1,6 +1,6 @@
-import { FC } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
-import { HEADER_MENU_LIST } from '@/utils/constants'
+import { HEADER_MENU_LIST, SIDEBAR_WHITE_LIST } from '@/utils/constants'
 import { Icon } from '@iconify/react'
 import logo from '@/assets/svgs/logo.svg'
 import { CSSTransition } from 'react-transition-group'
@@ -11,35 +11,59 @@ const Sidebar: FC<{
   setVisible: (visible: boolean) => void
 }> = ({ className, visible, setVisible }) => {
   const location = useLocation()
+  const [maskTrigger, setMaskTrigger] = useState(false)
+
+  useEffect(() => {
+    setMaskTrigger(false)
+    if (!SIDEBAR_WHITE_LIST.includes(location.pathname)) {
+      const timer = setTimeout(() => {
+        setMaskTrigger(true)
+      }, 300)
+      return () => {
+        clearTimeout(timer)
+      }
+    }
+  }, [location.pathname])
 
   return (
-    <CSSTransition in={visible} timeout={300} classNames='opacity-gradient' unmountOnExit>
-      <div
-        className={`border-#858585 border-1px border-r-solid select-none fixed top-0 bottom-0 w-60 bg-white z-10 ${className}`}>
-        <div className='px-10 h-16 flex items-center gap-2.5'>
-          <Icon
-            className='cursor-pointer'
-            width={24}
-            color='#858585'
-            icon='ant-design:menu-outlined'
+    <>
+      {!SIDEBAR_WHITE_LIST.includes(location.pathname) && maskTrigger && (
+        <CSSTransition in={visible} timeout={300} classNames='opacity-gradient' unmountOnExit>
+          <div
+            className='fixed top-0 left-0 w-full h-full bg-black bg-opacity-32 z-999'
             onClick={() => setVisible(false)}
           />
-          <img className='h-10 cursor-pointer' src={logo} alt='picals-logo' />
-        </div>
+        </CSSTransition>
+      )}
 
-        <ul className='list-none m-0 p-0'>
-          {HEADER_MENU_LIST.map((item) => (
-            <Link key={item.route} to={item.route}>
-              <li
-                className={`px-5 h-12 flex items-center gap-2.5 cursor-pointer hover:bg-#f5f5f5 transition-duration-300 ${location.pathname === item.route ? 'bg-#f5f5f5' : ''}`}>
-                <Icon color='#858585' width={20} icon={item.icon} />
-                <span className='font-size-14px color-#3d3d3d'>{item.name}</span>
-              </li>
-            </Link>
-          ))}
-        </ul>
-      </div>
-    </CSSTransition>
+      <CSSTransition in={visible} timeout={300} classNames='left-to-right' unmountOnExit>
+        <div
+          className={`border-#858585 border-1px border-r-solid select-none fixed top-0 bottom-0 w-60 bg-white z-1000 ${className}`}>
+          <div className='px-10 h-16 flex items-center gap-2.5'>
+            <Icon
+              className='cursor-pointer'
+              width={24}
+              color='#858585'
+              icon='ant-design:menu-outlined'
+              onClick={() => setVisible(false)}
+            />
+            <img className='h-10 cursor-pointer' src={logo} alt='picals-logo' />
+          </div>
+
+          <ul className='list-none m-0 p-0'>
+            {HEADER_MENU_LIST.map((item) => (
+              <Link key={item.route} to={item.route}>
+                <li
+                  className={`px-5 h-12 flex items-center gap-2.5 cursor-pointer hover:bg-#f5f5f5 transition-duration-300 ${location.pathname === item.route ? 'bg-#f5f5f5' : ''}`}>
+                  <Icon color='#858585' width={20} icon={item.icon} />
+                  <span className='font-size-14px color-#3d3d3d'>{item.name}</span>
+                </li>
+              </Link>
+            ))}
+          </ul>
+        </div>
+      </CSSTransition>
+    </>
   )
 }
 

--- a/src/components/common/header/user-dropdown.tsx
+++ b/src/components/common/header/user-dropdown.tsx
@@ -1,5 +1,5 @@
-import { FC } from 'react'
-import { Link } from 'react-router-dom'
+import { FC, useEffect } from 'react'
+import { Link, useLocation } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 import type { AppState } from '@/store/types'
 import { HEADER_DROPDOWN_LIST } from '@/utils/constants'
@@ -10,27 +10,34 @@ const UserDropdown: FC<{
   className?: string
   setVisible: (visible: boolean) => void
 }> = ({ visible, className, setVisible }) => {
+  const location = useLocation()
+
+  const userInfo = useSelector((state: AppState) => state.user.userInfo)
+
   const selectItem = (route: string) => {
     console.log(route)
   }
 
-  const userInfo = useSelector((state: AppState) => state.user.userInfo)
+  // 当在这个组件内部触发路由切换时，将visible设置为false
+  useEffect(() => {
+    setVisible(false)
+  }, [location.pathname])
 
   return (
     <>
       <CSSTransition in={visible} timeout={300} classNames='opacity-gradient' unmountOnExit>
         <div
-          className='fixed top-0 left-0 w-full h-full bg-black bg-opacity-16 z-999'
+          className='fixed top-0 left-0 w-full h-full bg-black bg-opacity-32 z-1999'
           onClick={() => setVisible(false)}
         />
       </CSSTransition>
 
       <CSSTransition in={visible} timeout={300} classNames='opacity-gradient' unmountOnExit>
         <div
-          className={`absolute flex flex-col w-50 rd-6px bg-white overflow-hidden z-1000 ${className}`}>
+          className={`absolute flex flex-col w-50 rd-6px bg-white overflow-hidden z-2000 ${className}`}>
           <div className='absolute top-0 left-0 w-full h-12.5 bg-#f5f5f5' />
           <div className='m-t-25px flex flex-col items-start justify-between h-25 p-l-2.5 p-r-2.5 z-1'>
-            <Link to={`/personal-center/${userInfo.id}`}>
+            <Link to={`/personal-center/${userInfo.id}/works`}>
               <div className='w-12.5 h-12.5 rd-full flex justify-center items-center overflow-hidden '>
                 <img className='w-12.5' src={userInfo.avatar} alt='avatar' />
               </div>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -56,6 +56,8 @@ a {
 }
 
 /* Specific global animations for the project */
+
+/* 透明度变化 */
 .opacity-gradient-enter {
   opacity: 0;
 }
@@ -78,6 +80,7 @@ a {
     transform 300ms;
 }
 
+/* 从下到上变化 */
 .down-to-up-enter {
   transform: translateY(100%);
 }
@@ -94,4 +97,23 @@ a {
 .down-to-up-exit-active {
   transition: transform 300ms;
   transform: translateY(calc(100% + 20px));
+}
+
+/* 从左到右变化 */
+.left-to-right-enter {
+  transform: translateX(-100%);
+}
+
+.left-to-right-enter-active {
+  transition: transform 300ms;
+  transform: translateX(0);
+}
+
+.left-to-right-exit {
+  transform: translateX(0);
+}
+
+.left-to-right-exit-active {
+  transition: transform 300ms;
+  transform: translateX(calc(-100% - 20px));
 }

--- a/src/test/data.ts
+++ b/src/test/data.ts
@@ -19,11 +19,14 @@ import type {
 export const labelList: LabelInfo[] = Array(100)
   .fill(0)
   .map((_, index) => {
+    const color = `#${Math.floor(Math.random() * 16777215)
+      .toString(16)
+      .padStart(6, '0')}`
     return {
       id: index.toString(),
       name: `标签${index}`,
       img: 'https://img.yzcdn.cn/vant/cat.jpeg',
-      color: `#${Math.floor(Math.random() * 16777215).toString(16)}`,
+      color,
     }
   })
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -56,4 +56,7 @@ export const HEADER_MENU_LIST: HeaderMenuItem[] = [
 ]
 
 // 哪些路由前缀要隐藏Header
-export const HEADER_WHITE_LIST: RegExp = /^\/(login|upload)/
+export const HEADER_WHITE_LIST: RegExp = /^\/login/
+
+// 哪些路由前缀不以蒙版形式展示Sidebar
+export const SIDEBAR_WHITE_LIST = ['/home', '/followed-new', '/explore']


### PR DESCRIPTION
演示一下目前重构完成的侧边栏的显示方式：
![image](https://github.com/nonhana/Picals-Frontend-React/assets/105428118/f4a7c3a8-ff20-4798-9e52-6d84db45c96f)
![image](https://github.com/nonhana/Picals-Frontend-React/assets/105428118/ffb0dd31-7ef7-4ac1-aa52-0c94a4c6bf91)
![image](https://github.com/nonhana/Picals-Frontend-React/assets/105428118/c3fcb113-ba07-440a-b462-8b46a5673bbe)
![image](https://github.com/nonhana/Picals-Frontend-React/assets/105428118/2e35ef01-5f6d-47ab-abb7-738ac7928652)
主要就是根据不同的路由，将pathname加了一下白名单，然后根据是否匹配来显示蒙版。
close #27 