### PR TITLE
feat: 完成个人中心收藏夹功能的编写

### DIFF
--- a/src/apis/favorite/index.ts
+++ b/src/apis/favorite/index.ts
@@ -2,9 +2,10 @@ import request from '@/service'
 import {
   FavoriteDetailInfo,
   IChangeFavoriteOrderReq,
+  ICopyFavoriteWorksReq,
   IEditFavoriteReq,
   IGetSearchResultNumReq,
-  IMoveWorkToFavoriteReq,
+  IMoveFavoriteWorksReq,
   INewFavoriteReq,
 } from './types'
 import { Id, Pagination, WorkNormalItem } from '../types'
@@ -78,5 +79,23 @@ export const getSearchResultNumAPI = (params: IGetSearchResultNumReq) => {
     url: '/api/favorite/search-count',
     method: 'GET',
     params,
+  })
+}
+
+// 移动作品到其他收藏夹
+export const moveFavoriteWorksAPI = (data: IMoveFavoriteWorksReq) => {
+  return request<IMoveFavoriteWorksReq, undefined>({
+    url: '/api/favorite/move',
+    method: 'POST',
+    data,
+  })
+}
+
+// 复制作品到其他收藏夹
+export const copyFavoriteWorksAPI = (data: ICopyFavoriteWorksReq) => {
+  return request<ICopyFavoriteWorksReq, undefined>({
+    url: '/api/favorite/copy',
+    method: 'POST',
+    data,
   })
 }

--- a/src/apis/favorite/index.ts
+++ b/src/apis/favorite/index.ts
@@ -54,15 +54,6 @@ export const getFavoriteDetailAPI = (params: Id) => {
   })
 }
 
-// 移动作品到其他收藏夹
-export const moveWorkToFavoriteAPI = (data: IMoveWorkToFavoriteReq) => {
-  return request<IMoveWorkToFavoriteReq, undefined>({
-    url: '/api/favorite/move',
-    method: 'POST',
-    data,
-  })
-}
-
 // 分页获取收藏夹作品列表
 export const getFavoriteWorkListAPI = (params: Pagination) => {
   return request<Pagination, WorkNormalItem[]>({

--- a/src/apis/favorite/types.ts
+++ b/src/apis/favorite/types.ts
@@ -34,17 +34,6 @@ export interface IChangeFavoriteOrderReq {
   }[]
 }
 
-export interface IMoveWorkToFavoriteReq {
-  /**
-   * 要移动到的收藏夹id
-   */
-  id: string
-  /**
-   * 选中的作品id列表
-   */
-  workIdList: string[]
-}
-
 export interface IGetSearchResultNumReq {
   keyword: string
   favoriteId: string

--- a/src/apis/favorite/types.ts
+++ b/src/apis/favorite/types.ts
@@ -38,6 +38,17 @@ export interface IGetSearchResultNumReq {
   keyword: string
   favoriteId: string
 }
+
+export interface IMoveFavoriteWorksReq {
+  idList: string[]
+  fromId: string
+  toId: string
+}
+
+export interface ICopyFavoriteWorksReq {
+  idList: string[]
+  toId: string
+}
 // # endregion
 
 // #region 响应体类型

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -2,9 +2,11 @@ import request from '@/service'
 import {
   IChangeEmailReq,
   IChangePasswordReq,
+  ICopyFavoriteWorksReq,
   IFavoriteActionsReq,
   ILoginReq,
   ILoginRes,
+  IMoveFavoriteWorksReq,
   IRefreshTokenReq,
   IRefreshTokenRes,
   IRegisterReq,
@@ -252,6 +254,24 @@ export const searchUserTotalAPI = (params: Keyword) => {
 export const favoriteActionsAPI = (data: IFavoriteActionsReq) => {
   return request<IFavoriteActionsReq, undefined>({
     url: '/api/user/collect',
+    method: 'POST',
+    data,
+  })
+}
+
+// 移动作品到其他收藏夹
+export const moveFavoriteWorksAPI = (data: IMoveFavoriteWorksReq) => {
+  return request<IMoveFavoriteWorksReq, undefined>({
+    url: '/api/user/move-collect',
+    method: 'POST',
+    data,
+  })
+}
+
+// 复制作品到其他收藏夹
+export const copyFavoriteWorksAPI = (data: ICopyFavoriteWorksReq) => {
+  return request<ICopyFavoriteWorksReq, undefined>({
+    url: '/api/user/copy-collect',
     method: 'POST',
     data,
   })

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -2,11 +2,9 @@ import request from '@/service'
 import {
   IChangeEmailReq,
   IChangePasswordReq,
-  ICopyFavoriteWorksReq,
   IFavoriteActionsReq,
   ILoginReq,
   ILoginRes,
-  IMoveFavoriteWorksReq,
   IRefreshTokenReq,
   IRefreshTokenRes,
   IRegisterReq,
@@ -254,24 +252,6 @@ export const searchUserTotalAPI = (params: Keyword) => {
 export const favoriteActionsAPI = (data: IFavoriteActionsReq) => {
   return request<IFavoriteActionsReq, undefined>({
     url: '/api/user/collect',
-    method: 'POST',
-    data,
-  })
-}
-
-// 移动作品到其他收藏夹
-export const moveFavoriteWorksAPI = (data: IMoveFavoriteWorksReq) => {
-  return request<IMoveFavoriteWorksReq, undefined>({
-    url: '/api/user/move-collect',
-    method: 'POST',
-    data,
-  })
-}
-
-// 复制作品到其他收藏夹
-export const copyFavoriteWorksAPI = (data: ICopyFavoriteWorksReq) => {
-  return request<ICopyFavoriteWorksReq, undefined>({
-    url: '/api/user/copy-collect',
     method: 'POST',
     data,
   })

--- a/src/apis/user/types.ts
+++ b/src/apis/user/types.ts
@@ -52,19 +52,9 @@ export interface IChangeEmailReq {
 
 export interface IFavoriteActionsReq {
   id: string
-  favoriteId: string
+  favoriteIds: string[]
 }
 
-export interface IMoveFavoriteWorksReq {
-  idList: string[]
-  fromId: string
-  toId: string
-}
-
-export interface ICopyFavoriteWorksReq {
-  idList: string[]
-  toId: string
-}
 // #endregion
 
 // #region 返回体类型

--- a/src/apis/user/types.ts
+++ b/src/apis/user/types.ts
@@ -54,6 +54,17 @@ export interface IFavoriteActionsReq {
   id: string
   favoriteId: string
 }
+
+export interface IMoveFavoriteWorksReq {
+  idList: string[]
+  fromId: string
+  toId: string
+}
+
+export interface ICopyFavoriteWorksReq {
+  idList: string[]
+  toId: string
+}
 // #endregion
 
 // #region 返回体类型

--- a/src/components/common/work-favorite-item/index.tsx
+++ b/src/components/common/work-favorite-item/index.tsx
@@ -69,7 +69,7 @@ const WorkFavoriteItem: FC<WorkFavoriteItemProps> = ({
           <div className='absolute top-10px right-10px'>
             <Icon
               width='32px'
-              color={chooseStatus ? '#0090F0' : '#fff'}
+              color={chooseStatus ? '#0090F0' : '#ffffff'}
               icon={
                 chooseStatus ? 'ant-design:check-square-filled' : 'ant-design:check-square-outlined'
               }
@@ -93,8 +93,8 @@ const WorkFavoriteItem: FC<WorkFavoriteItemProps> = ({
           </div>
         )}
         <Icon
-          className='absolute bottom-10px right-10px cursor-pointer'
-          width='24px'
+          className='p-10px absolute bottom-0 right-0 cursor-pointer'
+          width='44px'
           color={itemInfo.isLiked ? 'red' : '#3d3d3d'}
           icon={itemInfo.isLiked ? 'ant-design:heart-filled' : 'ant-design:heart-outlined'}
           onClick={() => like(itemInfo.id)}

--- a/src/components/personal-center/favorites/work-list.tsx
+++ b/src/components/personal-center/favorites/work-list.tsx
@@ -21,7 +21,8 @@ type WorkListProps = {
   handleSearch: (keyword: string) => void
   searchStatus: boolean
   setSearchStatus: (status: boolean) => void
-  refresh: () => void
+  refresh: () => Promise<void> // 刷新作品列表
+  like: (id: string) => void
 }
 
 const WorkList: FC<WorkListProps> = ({
@@ -33,6 +34,7 @@ const WorkList: FC<WorkListProps> = ({
   searchStatus,
   setSearchStatus,
   refresh,
+  like,
 }) => {
   const [messageApi, contextHolder] = message.useMessage()
   const { favoriteList } = useSelector((state: AppState) => state.favorite)
@@ -72,9 +74,6 @@ const WorkList: FC<WorkListProps> = ({
     setChosenWorkList([])
   }
 
-  const like = (id: string) => {
-    console.log(id)
-  }
   // 选中作品，将对应的作品选中状态取反
   const choose = (id: string) => {
     setChooseStatusList((prev) => {
@@ -108,7 +107,7 @@ const WorkList: FC<WorkListProps> = ({
     setChooseStatusList(new Array(workList.length).fill(false))
     setAllChosen(false)
     setChosenWorkList([])
-  }, [settingStatus])
+  }, [settingStatus, workList])
 
   useEffect(() => {
     setChosenWorkList(
@@ -125,9 +124,9 @@ const WorkList: FC<WorkListProps> = ({
   /* ----------Modal相关---------- */
   //#region
   const [moveModalStatus, setMoveModalStatus] = useState(false)
-  const [moveFolderId, setMoveFolderId] = useState<string>(folderId!)
+  const [moveFolderId, setMoveFolderId] = useState<string>('')
   const [copyModalStatus, setCopyModalStatus] = useState(false)
-  const [copyFolderId, setCopyFolderId] = useState<string>(folderId!)
+  const [copyFolderId, setCopyFolderId] = useState<string>('')
 
   const cancelConfirm = (idList: string[]) => {
     confirm({
@@ -139,22 +138,24 @@ const WorkList: FC<WorkListProps> = ({
       cancelText: '取消',
       async onOk() {
         await handleCancelFavorite(idList)
-        refresh()
+        await refresh()
         resetSettingStatus()
         messageApi.success('取消收藏成功')
       },
     })
   }
 
+  // 批量取消收藏
   const handleCancelFavorite = async (idList: string[]) => {
     try {
-      const promises = idList.map((id) => favoriteActionsAPI({ id, favoriteId: folderId! }))
+      const promises = idList.map((id) => favoriteActionsAPI({ id, favoriteIds: [folderId!] }))
       await Promise.all(promises)
     } catch (error) {
       console.log('出现错误了喵！！', error)
     }
   }
 
+  // 移动作品
   const onChooseMoveFolder = (e: RadioChangeEvent) => {
     setMoveFolderId(e.target.value)
   }
@@ -162,31 +163,36 @@ const WorkList: FC<WorkListProps> = ({
     try {
       await moveFavoriteWorksAPI({ idList, fromId: folderId!, toId: targetId })
       setMoveModalStatus(false)
-      refresh()
+      await refresh()
       resetSettingStatus()
       messageApi.success('移动成功')
     } catch (error) {
       console.log('出现错误了喵！！', error)
     }
   }
+  useEffect(() => {
+    if (!moveModalStatus) setMoveFolderId(folderId!)
+  }, [moveModalStatus, folderId])
 
-  const cancelMove = () => {
-    setMoveModalStatus(false)
-    setMoveFolderId(folderId!)
-  }
-
+  // 复制作品
   const onChooseCopyFolder = (e: RadioChangeEvent) => {
     setCopyFolderId(e.target.value)
   }
-  const copyConfirm = (folderId: string) => {
-    console.log('copy ' + chosenWorkList + ' to ' + folderId)
-    setCopyModalStatus(false)
-    messageApi.success('复制成功')
+  const copyConfirm = async (idList: string[], targetId: string) => {
+    try {
+      await copyFavoriteWorksAPI({ idList, toId: targetId })
+      setCopyModalStatus(false)
+      await refresh()
+      resetSettingStatus()
+      messageApi.success('复制成功')
+    } catch (error) {
+      console.log('出现错误了喵！！', error)
+      return
+    }
   }
-  const cancelCopy = () => {
-    setCopyModalStatus(false)
-    setCopyFolderId(folderId!)
-  }
+  useEffect(() => {
+    if (!copyModalStatus) setCopyFolderId(folderId!)
+  }, [copyModalStatus, folderId])
   //#endregion
 
   return (
@@ -281,7 +287,7 @@ const WorkList: FC<WorkListProps> = ({
         okText='移动'
         cancelText='取消'
         onOk={() => moveConfirm(chosenWorkList, moveFolderId)}
-        onCancel={cancelMove}>
+        onCancel={() => setMoveModalStatus(false)}>
         <div className='h-110 overflow-y-scroll'>
           <Radio.Group className='w-full' onChange={onChooseMoveFolder} value={moveFolderId}>
             {favoriteList.map((item) => (
@@ -306,8 +312,8 @@ const WorkList: FC<WorkListProps> = ({
         open={copyModalStatus}
         okText='复制'
         cancelText='取消'
-        onOk={() => copyConfirm(copyFolderId)}
-        onCancel={cancelCopy}>
+        onOk={() => copyConfirm(chosenWorkList, copyFolderId)}
+        onCancel={() => setCopyModalStatus(false)}>
         <div className='h-110 overflow-y-scroll'>
           <Radio.Group className='w-full' onChange={onChooseCopyFolder} value={copyFolderId}>
             {favoriteList.map((item) => (

--- a/src/components/work-detail/work-info/index.tsx
+++ b/src/components/work-detail/work-info/index.tsx
@@ -52,7 +52,7 @@ const WorkInfo: FC<WorkInfoProps> = ({
   // 添加当前作品到收藏夹
   const handleCollectWork = async () => {
     if (workInfo.isCollected) {
-      await favoriteActionsAPI({ id: workInfo.id, favoriteId: workInfo.favoriteId! })
+      await favoriteActionsAPI({ id: workInfo.id, favoriteIds: workInfo.favoriteIds! })
       setWorkInfo({ ...workInfo, isCollected: false })
     } else {
       setCollecting(true)
@@ -63,7 +63,7 @@ const WorkInfo: FC<WorkInfoProps> = ({
       setCollecting(false)
       return
     }
-    await favoriteActionsAPI({ id: workInfo.id, favoriteId: folderId })
+    await favoriteActionsAPI({ id: workInfo.id, favoriteIds: [folderId] })
     setCollecting(false)
     setWorkInfo({ ...workInfo, isCollected: true })
     messageApi.success('收藏成功')

--- a/src/pages/personal-center/my-favorites/index.tsx
+++ b/src/pages/personal-center/my-favorites/index.tsx
@@ -9,6 +9,7 @@ import {
   getFavoriteWorkListAPI,
   searchFavoriteWorkAPI,
   getSearchResultNumAPI,
+  likeActionsAPI,
 } from '@/apis'
 import Empty from '@/components/common/empty'
 
@@ -83,12 +84,24 @@ const MyFavorites: FC = () => {
     }
   }
 
-  const refresh = () => {
+  const refresh = async () => {
     setSearchTotal(0)
     setCurrent(1)
     setSearchCurrent(1)
     setSearchStatus(false)
-    getFavoriteWorkList()
+    await getFavoriteWorkList()
+  }
+
+  const like = async (id: string) => {
+    try {
+      await likeActionsAPI({ id })
+      setWorkList(
+        workList.map((item) => (item.id === id ? { ...item, isLiked: !item.isLiked } : item)),
+      )
+    } catch (error) {
+      console.log('出现错误了喵！！', error)
+      return
+    }
   }
 
   return (
@@ -108,6 +121,7 @@ const MyFavorites: FC = () => {
                 setSearchStatus={setSearchStatus}
                 handleSearch={handleSearch}
                 refresh={refresh}
+                like={like}
               />
             </>
           )

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './colorHue'
 export * from './constants'
 export * from './base64ToFile'
+export * from './sleep'

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,0 +1,1 @@
+export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -53,7 +53,7 @@ export interface WorkDetailInfo {
   labels: Option[]
   isLiked: boolean
   isCollected: boolean
-  favoriteId?: string
+  favoriteIds?: string[]
   isReprinted: boolean
   openComment: boolean
   isAIGenerated: boolean


### PR DESCRIPTION
这个功能属实是做了我好半天，到头来还是采用了后端多加接口的方式来实现了。

- 作品和收藏夹是多对多的关系，不仅是对不同用户来说，对自己来说也是如此。
- 批量编辑功能的实现。需要选中多个作品进行移动、复制等操作。
- 需要在进行分页功能的基础之上，再加一个搜索功能。**并且搜索功能本身也需要分页。**因此，相当于在同一个组件维护了两个状态，涉及到比较多的 useEffect 钩子使用。以后肯定还需要狠狠优化。
- 移动和复制功能，原本只是想交给前端调用 `favoriteActionsAPI` 一个函数来实现的，结果发现太过困难—— `Promise.all()` 方法有时候不管用，无法确保请求真正的先后顺序，遂交由后端进行新接口的实现。
- 
嗯，暂时先这样。接下来剩下一个搜索页，也是一个重量级。