### PR TITLE
feat: 替换原有的占位图片

### DIFF
--- a/src/components/common/label-img-item/index.tsx
+++ b/src/components/common/label-img-item/index.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react'
 import { Link } from 'react-router-dom'
+import { isWarmHue } from '@/utils'
 
 type LabelImgItemProps = {
   id: string
@@ -15,7 +16,10 @@ const LabelImgItem: FC<LabelImgItemProps> = ({ name, color, cover }) => {
       className='relative flex-shrink-0 w-118px h-118px rd-6px overflow-hidden flex items-center justify-center cursor-pointer hover:opacity-80'>
       <img
         className='w-118px'
-        src={cover || `https://dummyimage.com/400x400/${color.slice(1)}/ffffff&text=${name}`}
+        src={
+          cover ||
+          `https://fakeimg.pl/200x200/${color.slice(1)}/${isWarmHue(color) ? '3d3d3d' : 'ffffff'}?retina=1&font=noto&text=${name}`
+        }
         alt={name}
       />
       <div className='absolute w-118px h-118px top-0 left-0 bg-black opacity-32' />

--- a/src/components/personal-center/favorites/header.tsx
+++ b/src/components/personal-center/favorites/header.tsx
@@ -12,7 +12,7 @@ const Header: FC<HeaderProps> = ({ name, intro, creatorId, creatorName, cover, w
         <div className='w-40 h-40 flex justify-center items-center'>
           <img
             className='w-full h-full object-cover'
-            src={cover || `https://dummyimage.com/400x400&text=${name}`}
+            src={cover || `https://fakeimg.pl/400x400?font=noto&text=${name}`}
             alt={name}
           />
         </div>

--- a/src/components/search-result/label-info/index.tsx
+++ b/src/components/search-result/label-info/index.tsx
@@ -1,4 +1,5 @@
 import { FC, useEffect, useState } from 'react'
+import { useDispatch } from 'react-redux'
 import type { LabelDetailInfo } from '@/utils/types'
 import { Button } from 'antd'
 import LabelItem from '@/components/common/label-item'
@@ -6,15 +7,23 @@ import LayoutList from '@/components/common/layout-list'
 import { isWarmHue } from '@/utils'
 import { labelActionsAPI, getRecommendLabelListAPI } from '@/apis'
 import type { LabelInfo } from '@/utils/types'
+import { addLikedLabel, removeLikedLabel } from '@/store/modules/user'
 
 type LabelInfoProps = LabelDetailInfo & {
   like: () => void
 }
 
 const LabelInfo: FC<LabelInfoProps> = ({ id, name, color, cover, isMyLike, workCount, like }) => {
+  const dispatch = useDispatch()
+
   const handleLike = async () => {
     try {
       await labelActionsAPI({ id })
+      if (isMyLike) {
+        dispatch(removeLikedLabel(id))
+      } else {
+        dispatch(addLikedLabel({ id, name, color, cover }))
+      }
       like()
     } catch (error) {
       console.log('出现错误了喵！！', error)
@@ -46,7 +55,7 @@ const LabelInfo: FC<LabelInfoProps> = ({ id, name, color, cover, isMyLike, workC
               className='w-full h-full object-cover'
               src={
                 cover ||
-                `https://dummyimage.com/400x400/${color.slice(1)}/${isWarmHue(color) ? '3d3d3d' : 'ffffff'}&text=${name}`
+                `https://fakeimg.pl/200x200/${color.slice(1)}/${isWarmHue(color) ? '3d3d3d' : 'ffffff'}?retina=1&font=noto&text=${name}`
               }
               alt={name}
             />

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -24,6 +24,12 @@ const userStore = createSlice({
     setLikedLabels(state, action) {
       state.likedLabels = action.payload
     },
+    addLikedLabel(state, action) {
+      state.likedLabels.push(action.payload)
+    },
+    removeLikedLabel(state, action) {
+      state.likedLabels = state.likedLabels.filter((item) => item.id !== action.payload)
+    },
     setLoginStatus(state, action) {
       state.isLogin = action.payload
     },
@@ -43,10 +49,11 @@ const userStore = createSlice({
   },
 })
 
-const { setUserInfo, setLikedLabels, setLoginStatus, logout } = userStore.actions
+const { setUserInfo, setLikedLabels, addLikedLabel, removeLikedLabel, setLoginStatus, logout } =
+  userStore.actions
 
 const userReducer = userStore.reducer
 
 // 导出
-export { setUserInfo, setLikedLabels, setLoginStatus, logout }
+export { setUserInfo, setLikedLabels, addLikedLabel, removeLikedLabel, setLoginStatus, logout }
 export default userReducer


### PR DESCRIPTION
主要修复以下两个内容：

1. 用户点击喜欢某标签后，无法把它加到搜索栏；
2. 把原本的图片占位工具 dummyimage 改为 fakeimg，因为后者对中文的支持更好。